### PR TITLE
Added a fallback case for pointers without ["uuid"]

### DIFF
--- a/NodeKit/json_nodes/attributes/attributes.py
+++ b/NodeKit/json_nodes/attributes/attributes.py
@@ -39,7 +39,16 @@ ATTRIBUTE_TYPE_MAPPING = {
 
 
 def _get_pointer(element: Any) -> str:
-    return element["uuid"] if element else None
+    if not element:
+        return None
+    
+    try:
+        return element.get("uuid")
+    except AttributeError:
+        try:
+            return element["uuid"]
+        except (KeyError, TypeError):
+            return None
 
 
 def _set_items(element, name, value):


### PR DESCRIPTION
In Blender 4.5 with a particular Geometry node group, I was running into issues in attributes.py:41

```error
def _get_pointer(element: Any) -> str:

line 41, in _get_pointer
    return element["uuid"] if element else None
           ~~~~~~~^^^^^^^^
KeyError: 'bpy_struct[key]: key "uuid" not found'
```

The fix is to also check for element.get("uuid") which fixes the the issue.

**Orginal**:
```python
def _get_pointer(element: Any) -> str:
    return element["uuid"] if element else None
```

**Fix**:
```python
def _get_pointer(element: Any) -> str:
    if not element:
        return None
    try:
        return element.get("uuid")
    except AttributeError:
        try:
            return element["uuid"]
        except (KeyError, TypeError):
            return None
```
